### PR TITLE
Fix CSS variable exposure in copy to clipboard component.

### DIFF
--- a/molecule_copy-to-clipboard/src/copy-to-clipboard.ts
+++ b/molecule_copy-to-clipboard/src/copy-to-clipboard.ts
@@ -25,7 +25,7 @@ export class CopyToClipboard extends LitElement {
       opacity: 1;
     }
     .aodocs-copy-to-clipboard__text {
-      color: var(--aodocs-copy-to-clipboard-icon-color, rgba(0, 0, 0, 0.54));
+      color: var(--aodocs-copy-to-clipboard-text-color, rgba(0, 0, 0, 0.54));
     }
     .aodocs-copy-to-clipboard__icon {
       color: var(--aodocs-copy-to-clipboard-icon-color, rgba(0, 0, 0, 0.54));


### PR DESCRIPTION
The CSS variable exposed wan not used,  instead we were using the one for icon